### PR TITLE
externalize few variables and improve releases formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Starting branch to get range of commits
 
 Ending branch to get range of commits
 
+### `approval_statuses`
+
+Comma separated list of issue statuses treated as approved
+
+
+### `exclude_issue_types`
+
+Comma separated list of issue types to exclude from changelog
+
+
+### `include_pending_approval_section`
+
+Boolean flag indicating whether to include or exclude `Pending Approval` section
+
 ## Outputs
 
 ### `changelog_message`

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,18 @@ inputs:
         description: 'Ending branch to get range of commits'
         default: 'master'
         required: false
+    approval_statuses:
+        description: 'Comma separated list of issue statuses treated as approved'
+        default: 'Done,Closed,Accepted'
+        required: false
+    exclude_issue_types:
+        description: 'Comma separated list of issue types to exclude from changelog'
+        default: 'Sub-task'
+        required: false
+    include_pending_approval_section:
+        description: 'Boolean flag indicating whether to include or exclude `Pending Approval` section'
+        default: 'true'
+        required: false
 outputs:
     changelog_message:
         description: 'Generated changelog entry'

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const template = `
 <% if (jira.releaseVersions && jira.releaseVersions.length) {  %>
 Release version: <%= jira.releaseVersions[0].name -%>
 <% jira.releaseVersions.sort((a, b) => a.projectKey.localeCompare(b.projectKey)).forEach((release) => { %>
-  * [<%= release.projectKey %>](<%= jira.baseUrl + '/projects/' + release.projectKey + '/versions/' + release.id -%>)
+  * [<%= release.projectKey %>](<%= jira.baseUrl + '/projects/' + release.projectKey + '/versions/' + release.id %>) <% -%>
 <% }); -%>
 <% } %>
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const core = require('@actions/core');
-const github = require('@actions/github');
 const _ = require('lodash');
 const Entities = require('html-entities');
 const ejs = require('ejs');
@@ -16,8 +15,8 @@ const config = {
     },
     baseUrl: core.getInput('jira_base_url'),
     ticketIDPattern: RegExpFromString(core.getInput('jira_ticket_id_pattern')),
-    approvalStatus: ['Done', 'Closed', 'Accepted'],
-    excludeIssueTypes: ['Sub-task'],
+    approvalStatus: core.getInput('approval_statuses').split(",").filter(x => x !== ""),
+    excludeIssueTypes: core.getInput('exclude_issue_types').split(",").filter(x => x !== ""),
     includeIssueTypes: [],
   },
   sourceControl: {
@@ -33,8 +32,8 @@ const config = {
 const template = `
 <% if (jira.releaseVersions && jira.releaseVersions.length) {  %>
 Release version: <%= jira.releaseVersions[0].name -%>
-<% jira.releaseVersions.forEach((release) => { %>
-  * <%= release.projectKey %>: <%= jira.baseUrl + '/projects/' + release.projectKey + '/versions/' + release.id -%>
+<% jira.releaseVersions.sort((a, b) => a.projectKey.localeCompare(b.projectKey)).forEach((release) => { %>
+  * [<%= release.projectKey %>](<%= jira.baseUrl + '/projects/' + release.projectKey + '/versions/' + release.id -%>)
 <% }); -%>
 <% } %>
 
@@ -52,6 +51,7 @@ Other Commits
 <% }); -%>
 <% if (!commits.noTickets.length) {%> ~ None ~ <% } %>
 
+<% if (includePendingApprovalSection) { %>
 Pending Approval
 ---------------------
 <% tickets.pendingByOwner.forEach((owner) => { %>
@@ -61,6 +61,7 @@ Pending Approval
 <% }); -%>
 <% }); -%>
 <% if (!tickets.pendingByOwner.length) {%> ~ None. Yay! ~ <% } %>
+<% } %>
 `;
 
 function generateReleaseVersionName() {
@@ -152,6 +153,7 @@ async function main() {
       baseUrl: config.jira.baseUrl,
       releaseVersions: jira.releaseVersions,
     };
+    data.includePendingApprovalSection = core.getInput('include_pending_approval_section') === 'true';
 
     const entitles = new Entities.AllHtmlEntities();
     const changelogMessage = ejs.render(template, data);


### PR DESCRIPTION
- externalise jira `approvalStatus` parameter
- externalise jira `excludeIssueTypes` parameter
- add `include_pending_approval_section` to optionally remove pending approval section
- sort release list based on project key
- display links to project release as markdown hyperlink `[project-key](release-link)`